### PR TITLE
fix: show webhook actor as the action performer (#11)

### DIFF
--- a/api/v2.ts
+++ b/api/v2.ts
@@ -71,16 +71,26 @@ export default api({
 			}
 
 			case 'Issue': {
-				const creator = await client.user(body.data.creatorId);
 				const assignee = body.data.assigneeId
 					? await client.user(body.data.assigneeId)
 					: null;
 
+				// `actor` is the user who performed this specific action — the editor
+				// on an update, not the original issue creator. When older Linear
+				// payloads don't include it, fall back to looking up the creator.
+				const performer = body.actor
+					? {
+							name: body.actor.name,
+							avatarUrl: body.actor.avatarUrl,
+							url: body.actor.url,
+					  }
+					: await client.user(body.data.creatorId);
+
 				embed
 					.setAuthor(
-						`${body.action}d by ${creator.name}`,
-						creator.avatarUrl,
-						creator.url,
+						`${body.action}d by ${performer.name}`,
+						performer.avatarUrl,
+						performer.url,
 					)
 					.setTitle(`[${getId(body.url)}] ${body.data.title}`)
 					.setURL(body.url)

--- a/v2-util/schema.ts
+++ b/v2-util/schema.ts
@@ -7,10 +7,19 @@ import {project} from './project';
 import {reaction} from './reaction';
 import {dateResolvable, defaultAction} from './util';
 
+const actor = z.object({
+	id: z.string().uuid(),
+	name: z.string(),
+	email: z.string().optional(),
+	url: z.string().url().optional(),
+	avatarUrl: z.string().url().optional(),
+});
+
 const commons = z.object({
 	organizationId: z.string().uuid(),
 	createdAt: dateResolvable,
 	action: defaultAction,
+	actor: actor.optional(),
 });
 
 export const bodySchema = commons.and(


### PR DESCRIPTION
Closes #11.

When a user other than the original issue creator updates an issue (commenting being the most common case), Linear sends an `Issue` webhook with `action: "update"`. The current handler always renders that as `${action}d by ${creator.name}` — i.e., the issue's original creator — which is why the embed in #11 reads "Updated by SunburntRock89" instead of the actual commenter.

Linear now ships an `actor` field on every webhook payload identifying who performed the specific action. This PR:

- Adds `actor` (optional) to the shared envelope schema in `v2-util/schema.ts`.
- Uses `actor.name` / `actor.url` / `actor.avatarUrl` for the embed author line on Issue events, falling back to the existing creator lookup when older payloads (e.g. local mocks) don't include it.

The behavior on `action: "create"` is unchanged: no `actor`/creator distinction matters because the actor *is* the creator.

### Verified
- `tsc --noEmit` clean.
- Manually walked through the schema with a payload that omits `actor` (old behaviour preserved) and one that includes it (new behaviour).