### PR TITLE
feat: route issue events by project to different webhooks (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 Please visit [lds.alistair.cloud](https://lds.alistair.cloud) which documents the setup. In short, we form a URL that contains the Discord webhook ID and Token, and use that as our linear URL. That way we can use the body with ID and Token in a stateless environment.
 
+### Routing by project (optional)
+
+To send events for a specific Linear project to a different Discord channel, set the `LDS_PROJECT_ROUTES` environment variable to a JSON object mapping the Linear `projectId` to a full Discord webhook URL:
+
+```json
+{
+  "11111111-1111-1111-1111-111111111111": "https://discord.com/api/webhooks/ID1/TOKEN1",
+  "22222222-2222-2222-2222-222222222222": "https://discord.com/api/webhooks/ID2/TOKEN2"
+}
+```
+
+Issue events whose `projectId` matches one of the keys are delivered to that webhook; everything else (and any issue without a project) falls back to the default webhook encoded in the request URL. Closes #13.
+
 ### Video Guide
 
 I've made a small video guide to visually demonstrate setup. You can watch it on [YouTube](https://youtu.be/QgDt8yUnQcA).

--- a/api/v2.ts
+++ b/api/v2.ts
@@ -6,6 +6,7 @@ import {bodySchema} from '../v2-util/schema';
 import fetch from 'node-fetch';
 import {Label} from '../v1-util/_types';
 import {api} from '../v2-util/api';
+import {resolveWebhookUrl} from '../v2-util/routes';
 import {getId} from '../v2-util/util';
 
 const querySchema = z.object({
@@ -166,7 +167,15 @@ export default api({
 			}
 		}
 
-		const webhook = `https://discord.com/api/webhooks/${webhookId}/${webhookToken}`;
+		const defaultWebhook = `https://discord.com/api/webhooks/${webhookId}/${webhookToken}`;
+
+		// Issue events can be routed to a project-specific webhook via the
+		// LDS_PROJECT_ROUTES env var; everything else falls through to the
+		// default webhook from the request URL.
+		const projectId =
+			body.type === 'Issue' ? body.data.projectId : undefined;
+
+		const webhook = resolveWebhookUrl(projectId, defaultWebhook);
 
 		await fetch(webhook, {
 			method: 'POST',

--- a/v2-util/issue.ts
+++ b/v2-util/issue.ts
@@ -38,6 +38,7 @@ const commons = z.object({
 	subscriberIds: z.array(z.string().uuid()),
 	creatorId: z.string().uuid(),
 	labelIds: z.array(z.string().uuid()),
+	projectId: z.string().uuid().optional(),
 	state,
 	team,
 	labels: z.array(label).optional(),

--- a/v2-util/routes.ts
+++ b/v2-util/routes.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-project webhook routing.
+ *
+ * Set `LDS_PROJECT_ROUTES` to a JSON object mapping a Linear `projectId` to a
+ * full Discord webhook URL. When an Issue event arrives whose `projectId`
+ * matches one of these entries, the embed is sent to that webhook instead of
+ * the default one encoded in the request URL.
+ *
+ * Example:
+ *   LDS_PROJECT_ROUTES='{
+ *     "11111111-1111-1111-1111-111111111111": "https://discord.com/api/webhooks/ID1/TOKEN1",
+ *     "22222222-2222-2222-2222-222222222222": "https://discord.com/api/webhooks/ID2/TOKEN2"
+ *   }'
+ */
+
+type RouteMap = Record<string, string>;
+
+let cached: RouteMap | null = null;
+
+export function getProjectRoutes(env = process.env.LDS_PROJECT_ROUTES): RouteMap {
+	if (cached) {
+		return cached;
+	}
+
+	if (!env) {
+		cached = {};
+		return cached;
+	}
+
+	try {
+		const parsed = JSON.parse(env);
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			cached = parsed as RouteMap;
+			return cached;
+		}
+	} catch (err) {
+		console.warn('Failed to parse LDS_PROJECT_ROUTES as JSON:', err);
+	}
+
+	cached = {};
+	return cached;
+}
+
+export function resolveWebhookUrl(
+	projectId: string | undefined,
+	defaultUrl: string,
+): string {
+	if (!projectId) {
+		return defaultUrl;
+	}
+	const routes = getProjectRoutes();
+	return routes[projectId] ?? defaultUrl;
+}
+
+// Exposed so tests can reset state between cases.
+export function __resetRouteCache() {
+	cached = null;
+}


### PR DESCRIPTION
Closes #13.

Adds an opt-in way to deliver Linear Issue events for a specific project to a different Discord channel without standing up a second deployment.

### How it works

Set the `LDS_PROJECT_ROUTES` environment variable to a JSON object mapping Linear `projectId` → Discord webhook URL:

```json
{
  "11111111-1111-1111-1111-111111111111": "https://discord.com/api/webhooks/ID1/TOKEN1",
  "22222222-2222-2222-2222-222222222222": "https://discord.com/api/webhooks/ID2/TOKEN2"
}
```

An incoming Issue event whose `data.projectId` matches one of the keys is delivered to the override webhook; everything else (including issues with no project, and all non-Issue events) falls through to the default webhook encoded in the request URL. No URL changes required on Linear's side.

### Notes

- The env var is parsed once per cold start and cached.
- A malformed JSON value logs a warning and is treated as if no routes were configured, so a typo can't take an existing deployment down.
- `projectId` is added as an optional field on the existing Issue schema.

### Verified
- `tsc --noEmit` clean.
- Unit-checked the resolver against the no-env, matching, non-matching, missing-projectId, and malformed-JSON cases.