### PR TITLE
feat: verify Linear webhook signatures via signing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Please visit [lds.alistair.cloud](https://lds.alistair.cloud) which documents the setup. In short, we form a URL that contains the Discord webhook ID and Token, and use that as our linear URL. That way we can use the body with ID and Token in a stateless environment.
 
+### Verifying webhook signatures
+
+Linear webhooks are authenticated with an HMAC-SHA256 signing secret, shown when a webhook is created in Linear's settings. Set this value as the `LINEAR_WEBHOOK_SECRET` environment variable on your deployment (e.g. in the Vercel project settings). Requests that don't carry a matching `Linear-Signature` header — or whose `webhookTimestamp` is more than 60 seconds off — are rejected with `401`.
+
+The previous source-IP allowlist has been removed: Linear has expanded its egress IPs since then, and the official guidance is to rely on the signing secret.
+
 ### Video Guide
 
 I've made a small video guide to visually demonstrate setup. You can watch it on [YouTube](https://youtu.be/QgDt8yUnQcA).

--- a/api/v2.ts
+++ b/api/v2.ts
@@ -7,12 +7,30 @@ import fetch from 'node-fetch';
 import {Label} from '../v1-util/_types';
 import {api} from '../v2-util/api';
 import {getId} from '../v2-util/util';
+import {verifyLinearSignature} from '../v2-util/verify';
+import type {VercelRequest} from '@vercel/node';
+
+// Disable Vercel's automatic body parser so we can verify the HMAC
+// signature against the exact raw request bytes Linear signed.
+export const config = {
+	api: {bodyParser: false},
+};
+
+const TIMESTAMP_TOLERANCE_MS = 60 * 1000;
 
 const querySchema = z.object({
 	api: z.string(),
 	token: z.string(),
 	id: z.string(),
 });
+
+async function readRawBody(req: VercelRequest): Promise<Buffer> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of req) {
+		chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+	}
+	return Buffer.concat(chunks);
+}
 
 const enum Colors {
 	LINEAR_PURPLE = '#5864d9',
@@ -27,14 +45,22 @@ const footer = 'Linear App • ⚡ lds.alistair.cloud';
 
 export default api({
 	async POST(req) {
-		// Linear's trusted ip range, this comes from
-		// https://developers.linear.app/docs/graphql/webhooks#how-does-a-webhook-work
-		const {success} = z
-			.enum(['35.231.147.226', '35.243.134.228'])
-			.safeParse(req.headers['x-vercel-forwarded-for']);
+		const secret = process.env.LINEAR_WEBHOOK_SECRET;
 
-		if (!success && process.env.NODE_ENV !== 'development') {
-			throw new HttpException(400, 'sus');
+		if (!secret) {
+			throw new HttpException(
+				500,
+				'Server is missing the LINEAR_WEBHOOK_SECRET environment variable.',
+			);
+		}
+
+		const rawHeader = req.headers['linear-signature'];
+		const signatureHeader = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+
+		const rawBody = await readRawBody(req);
+
+		if (!verifyLinearSignature(secret, signatureHeader, rawBody)) {
+			throw new HttpException(401, 'Invalid Linear webhook signature.');
 		}
 
 		const {
@@ -49,7 +75,16 @@ export default api({
 		});
 
 		// const body = bodySchema.parse(req.body);
-		const body = req.body as z.infer<typeof bodySchema>;
+		const body = JSON.parse(rawBody.toString('utf8')) as z.infer<
+			typeof bodySchema
+		> & {webhookTimestamp?: number};
+
+		if (
+			typeof body.webhookTimestamp === 'number' &&
+			Math.abs(Date.now() - body.webhookTimestamp) > TIMESTAMP_TOLERANCE_MS
+		) {
+			throw new HttpException(401, 'Webhook timestamp is outside the tolerance window.');
+		}
 
 		const embed = new MessageEmbed()
 			.setColor(Colors.LINEAR_PURPLE)

--- a/v2-util/verify.ts
+++ b/v2-util/verify.ts
@@ -1,0 +1,38 @@
+import crypto from 'crypto';
+
+/**
+ * Verify a Linear webhook signature.
+ *
+ * Linear signs each webhook with the HMAC-SHA256 of the raw request body using
+ * the signing secret shown when the webhook is created. The hex digest is sent
+ * in the `linear-signature` header.
+ *
+ * See: https://linear.app/developers/webhooks#securing-webhooks
+ */
+export function verifyLinearSignature(
+	secret: string,
+	headerSignature: string | undefined,
+	rawBody: Buffer,
+): boolean {
+	if (typeof headerSignature !== 'string' || headerSignature.length === 0) {
+		return false;
+	}
+
+	let provided: Buffer;
+	try {
+		provided = Buffer.from(headerSignature, 'hex');
+	} catch {
+		return false;
+	}
+
+	const computed = crypto
+		.createHmac('sha256', secret)
+		.update(rawBody)
+		.digest();
+
+	if (provided.length !== computed.length) {
+		return false;
+	}
+
+	return crypto.timingSafeEqual(provided, computed);
+}


### PR DESCRIPTION
Fixes the regression where every Linear webhook delivery to this project currently returns:

```json
{"success":false,"data":null,"message":"sus"}
```

### Background

The current handler authenticates requests by comparing `x-vercel-forwarded-for` against a hard-coded two-IP allowlist. Linear has since expanded its egress IPs (six are documented now), so every legitimate webhook fails the check and Linear logs them as 400s.

Linear's own [docs](https://linear.app/developers/webhooks#securing-webhooks) point operators at HMAC-SHA256 signing secrets as the supported authentication mechanism going forward, so this PR moves to that.

### What changes

- Disable Vercel's automatic body parser on `api/v2.ts`. The HMAC must be computed over the exact bytes Linear signed, and Vercel's JSON parser mutates them.
- Add `v2-util/verify.ts` — a small constant-time verifier (`crypto.timingSafeEqual`) for the `linear-signature` header.
- Read the raw body, verify it against `LINEAR_WEBHOOK_SECRET`, then `JSON.parse` and continue with the existing flow.
- Reject requests whose `webhookTimestamp` is more than 60 seconds away from the server clock (replay protection, also straight from Linear's docs).
- Require `LINEAR_WEBHOOK_SECRET`; surface a 500 if the env var isn't configured so misconfiguration is obvious.
- Remove the stale IP allowlist.
- Document the env var and the migration step in README.

### Migration

Existing deployments need to copy the signing secret shown in Linear's webhook settings UI and set it as `LINEAR_WEBHOOK_SECRET` (e.g. in Vercel's project settings → Environment Variables). No URL changes; the signing secret lives entirely on the deployment side.

### Verified
- `tsc --noEmit` clean.
- Verifier exercised against the valid case, wrong-secret, wrong-body, missing-header, malformed-hex, and empty-string cases — all behave correctly.